### PR TITLE
Adjustements to UI and wording

### DIFF
--- a/src/ActionRepeater.UI/MainWindow.xaml
+++ b/src/ActionRepeater.UI/MainWindow.xaml
@@ -26,12 +26,7 @@
                             <SolidColorBrush x:Key="TopNavigationViewItemForegroundPointerOver" Color="White" Opacity="0.8"/>
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
-                    <Style x:Name="MenuItemDescriptorTextBlock" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
-                        <Setter Property="VerticalAlignment" Value="Center"/>
-                        <Setter Property="Margin" Value="5 0 0 0"/>
-                    </Style>
                 </ResourceDictionary>
-               
             </NavigationView.Resources>
             
             <NavigationView.MenuItems>

--- a/src/ActionRepeater.UI/MainWindow.xaml
+++ b/src/ActionRepeater.UI/MainWindow.xaml
@@ -39,21 +39,17 @@
                 <NavigationViewItem x:Name="_navViewOffsetItem" Width="35" IsEnabled="False"/>
                 <!-- binding the tag suddenly stopped working for some fucking reason, so now its hardcoded -->
                 <NavigationViewItem Tag="h">
-                    <NavigationViewItem.Content>
-                        <StackPanel Orientation="Horizontal">
-                       
-                        <SymbolIcon Symbol="Home"/>
-                            <TextBlock Text="Home" Style="{StaticResource MenuItemDescriptorTextBlock}"/>
-                        </StackPanel>
-                    </NavigationViewItem.Content>
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <FontIcon Glyph="&#xE80F;" FontSize="16"/>
+                        <TextBlock Text="Home"/>
+                    </StackPanel>
                 </NavigationViewItem>
+
                 <NavigationViewItem Tag="o">
-                    <NavigationViewItem.Content>
-                        <StackPanel Orientation="Horizontal">
-                            <SymbolIcon Symbol="Setting"/>
-                            <TextBlock Text="Settings" Style="{StaticResource MenuItemDescriptorTextBlock}"/>
-                        </StackPanel>
-                    </NavigationViewItem.Content>
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <FontIcon Glyph="&#xE713;" FontSize="16"/>
+                        <TextBlock Text="Settings"/>
+                    </StackPanel>
                 </NavigationViewItem>
             </NavigationView.MenuItems>
 

--- a/src/ActionRepeater.UI/MainWindow.xaml
+++ b/src/ActionRepeater.UI/MainWindow.xaml
@@ -117,6 +117,7 @@
             </MenuBarItem>
 
         </MenuBar>
+
         <!-- 1p height line to cover some random gray line in the app in light mode. -->
         <!-- i have no clue where it came from ive tried setting the background and border brush on everything in this view -->
         <Rectangle x:Name="_rectangle" Margin="0,30,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Top" Height="1" Fill="{ThemeResource AppBackgroundThemeBrush}"/>

--- a/src/ActionRepeater.UI/MainWindow.xaml
+++ b/src/ActionRepeater.UI/MainWindow.xaml
@@ -26,15 +26,35 @@
                             <SolidColorBrush x:Key="TopNavigationViewItemForegroundPointerOver" Color="White" Opacity="0.8"/>
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
+                    <Style x:Name="MenuItemDescriptorTextBlock" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}">
+                        <Setter Property="VerticalAlignment" Value="Center"/>
+                        <Setter Property="Margin" Value="5 0 0 0"/>
+                    </Style>
                 </ResourceDictionary>
+               
             </NavigationView.Resources>
             
             <NavigationView.MenuItems>
                 <!-- space for the file dropdown button -->
                 <NavigationViewItem x:Name="_navViewOffsetItem" Width="35" IsEnabled="False"/>
                 <!-- binding the tag suddenly stopped working for some fucking reason, so now its hardcoded -->
-                <NavigationViewItem Tag="h" Content="Home"/>
-                <NavigationViewItem Tag="o" Content="Options"/>
+                <NavigationViewItem Tag="h">
+                    <NavigationViewItem.Content>
+                        <StackPanel Orientation="Horizontal">
+                       
+                        <SymbolIcon Symbol="Home"/>
+                            <TextBlock Text="Home" Style="{StaticResource MenuItemDescriptorTextBlock}"/>
+                        </StackPanel>
+                    </NavigationViewItem.Content>
+                </NavigationViewItem>
+                <NavigationViewItem Tag="o">
+                    <NavigationViewItem.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <SymbolIcon Symbol="Setting"/>
+                            <TextBlock Text="Settings" Style="{StaticResource MenuItemDescriptorTextBlock}"/>
+                        </StackPanel>
+                    </NavigationViewItem.Content>
+                </NavigationViewItem>
             </NavigationView.MenuItems>
 
             <Grid Padding="0,10,0,0" Background="{ThemeResource AppBackgroundThemeBrush}">
@@ -77,11 +97,11 @@
             </MenuBar.Resources>
 
             <!-- binding the commands doesnt work for some reason, so theyre set in the constructor -->
-            
+
             <MenuBarItem Title="File">
                 <MenuFlyoutItem x:Name="_openMenuItem" Text="Open">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Glyph="&#xE8E5;"/>
+                        <SymbolIcon Symbol="OpenFile"/>
                     </MenuFlyoutItem.Icon>
                     <MenuFlyoutItem.KeyboardAccelerators>
                         <KeyboardAccelerator Modifiers="Control" Key="O"/>
@@ -90,7 +110,7 @@
 
                 <MenuFlyoutItem x:Name="_saveMenuItem" Text="Save">
                     <MenuFlyoutItem.Icon>
-                        <FontIcon Glyph="&#xE792;"/>
+                        <SymbolIcon Symbol="Save"/>
                     </MenuFlyoutItem.Icon>
                     <MenuFlyoutItem.KeyboardAccelerators>
                         <KeyboardAccelerator Modifiers="Control" Key="S"/>
@@ -101,7 +121,6 @@
             </MenuBarItem>
 
         </MenuBar>
-
         <!-- 1p height line to cover some random gray line in the app in light mode. -->
         <!-- i have no clue where it came from ive tried setting the background and border brush on everything in this view -->
         <Rectangle x:Name="_rectangle" Margin="0,30,0,0" HorizontalAlignment="Stretch" VerticalAlignment="Top" Height="1" Fill="{ThemeResource AppBackgroundThemeBrush}"/>

--- a/src/ActionRepeater.UI/Pages/HomePage.xaml
+++ b/src/ActionRepeater.UI/Pages/HomePage.xaml
@@ -33,10 +33,11 @@
 
                 <AppBarSeparator Margin="5,0,5,0" />
 
+
                 <StackPanel Padding="5,0,5,0"
                             ToolTipService.Placement="Bottom"
-                            ToolTipService.ToolTip="Number of times to repeat the actions.&#x0d;&#x0a;Negtive number = Repeat infinitely">
-                    <TextBlock Text="Repeat Actions ⓘ"
+                            ToolTipService.ToolTip="Controls how often the input sequence is repeated.&#x0d;&#x0a;A negative number causes the inputs to repeat indefinitely.">
+                    <TextBlock Text="Repetitions"
                                FontSize="15"
                                HorizontalAlignment="Center"
                                Margin="0,0,0,5"/>
@@ -51,7 +52,6 @@
                                ValidationMode="InvalidInputOverwritten"
                                Value="{x:Bind _vm.PlayRepeatCount, Mode=TwoWay}"/>
                 </StackPanel>
-
                 <AppBarSeparator Margin="5,0,5,0" />
 
                 <ctrls:CmdBarToggleButton Glyph="&#xF128;"

--- a/src/ActionRepeater.UI/Pages/HomePage.xaml
+++ b/src/ActionRepeater.UI/Pages/HomePage.xaml
@@ -36,7 +36,7 @@
 
                 <StackPanel Padding="5,0,5,0"
                             ToolTipService.Placement="Bottom"
-                            ToolTipService.ToolTip="Controls how often the input sequence is repeated.&#x0d;&#x0a;A negative number causes the inputs to repeat indefinitely.">
+                            ToolTipService.ToolTip="Specifies the number of repetitions of the action sequence.&#x0d;&#x0a;A negative number causes the inputs to repeat indefinitely.">
                     <TextBlock Text="Repetitions"
                                FontSize="15"
                                HorizontalAlignment="Center"

--- a/src/ActionRepeater.UI/Views/ActionListView.xaml
+++ b/src/ActionRepeater.UI/Views/ActionListView.xaml
@@ -26,7 +26,7 @@
                    Margin="67,0,45,1"
                    VerticalAlignment="Bottom"
                    HorizontalAlignment="Right"
-                   Text="show key auto-repeat actions"/>
+                   Text="Show character repeat actions"/>
 
         <ToggleSwitch x:Name="ShowAutoRepeatToggle"
                       OnContent=""

--- a/src/ActionRepeater.UI/Views/ActionListView.xaml
+++ b/src/ActionRepeater.UI/Views/ActionListView.xaml
@@ -26,7 +26,7 @@
                    Margin="67,0,45,1"
                    VerticalAlignment="Bottom"
                    HorizontalAlignment="Right"
-                   Text="Show character repeat actions"/>
+                   Text="Show key auto-repeat actions"/>
 
         <ToggleSwitch x:Name="ShowAutoRepeatToggle"
                       OnContent=""

--- a/src/ActionRepeater.Win32/Synch/Utilities/HighResolutionWaiter.cs
+++ b/src/ActionRepeater.Win32/Synch/Utilities/HighResolutionWaiter.cs
@@ -45,6 +45,7 @@ public sealed class HighResolutionWaiter : IDisposable
 
         if (!SetWaitableTimer(_timerHandle, &time, 0, null, null, false))
         {
+            // TODO: call KillTimer when exiting app to avoid exception being thrown when app is closed during playback
             throw new Win32Exception();
         }
 

--- a/src/ActionRepeater.Win32/Synch/Utilities/HighResolutionWaiter.cs
+++ b/src/ActionRepeater.Win32/Synch/Utilities/HighResolutionWaiter.cs
@@ -45,7 +45,6 @@ public sealed class HighResolutionWaiter : IDisposable
 
         if (!SetWaitableTimer(_timerHandle, &time, 0, null, null, false))
         {
-            // TODO: call KillTimer when exiting app to avoid exception being thrown when app is closed during playback
             throw new Win32Exception();
         }
 


### PR DESCRIPTION
- Use statically-typed symbols w/ `SymbolIcon` instead of raw glyphs
- Use icons instead of text for navigation items, as they visually clash with the textual `MenuItem`
- Change wording and capitalization in some places
- Add TODO in Win32 high-res timer layer

Open to improvement suggestions 👍 